### PR TITLE
Fix: ReasoningTypeAccCalculator function error in EgoTaskQA

### DIFF
--- a/EgoTaskQA/main_end2end.py
+++ b/EgoTaskQA/main_end2end.py
@@ -26,10 +26,9 @@ from transformers import (
     get_cosine_schedule_with_warmup)
 
 from EgoTaskQA_dataset import EgoTaskQA, collate_func
-from baselines.utils.utils import ReasongingTypeAccCalculator
 from transforms import init_transform_dict, init_video_transform_dict
 import torch.distributed as dist
-from utils.util import state_dict_data_parallel_fix
+from utils.util import state_dict_data_parallel_fix, ReasongingTypeAccCalculator
 
 
 class AllGather_multi(torch.autograd.Function):

--- a/EgoTaskQA/utils/util.py
+++ b/EgoTaskQA/utils/util.py
@@ -20,6 +20,46 @@ import numpy as np
 import psutil
 
 
+class ReasongingTypeAccCalculator():
+    def __init__(self, reasoning_types):
+        '''
+        params: reasoning_types: list of strings
+        '''
+        self.reasoning_types = reasoning_types
+        self.true_count_dct = {}
+        self.all_count_dct = {}
+        self.acc_dct = {}
+        for reasoning_type in self.reasoning_types:
+            self.true_count_dct[reasoning_type] = 0
+            self.all_count_dct[reasoning_type] = 0
+            self.acc_dct[reasoning_type] = 0
+
+    def update(self, reasoning_type_lst, pred, label):
+        '''
+        params: reasoning_type_lst: list of list of strings
+        '''
+        res = (pred == label)
+        for i, q_reasoning_types in enumerate(reasoning_type_lst):
+            for reasoning_type in q_reasoning_types:
+                if res[i]:
+                    self.true_count_dct[reasoning_type] += 1
+                self.all_count_dct[reasoning_type] += 1
+
+    def reset(self):
+        for reasoning_type in self.reasoning_types:
+            self.true_count_dct[reasoning_type] = 0
+            self.all_count_dct[reasoning_type] = 0
+            self.acc_dct[reasoning_type] = 0
+
+    def get_acc(self):
+        for reasoning_type in self.reasoning_types:
+            if self.all_count_dct[reasoning_type] == 0:
+                self.acc_dct[reasoning_type] = 0
+            else:
+                self.acc_dct[reasoning_type] = self.true_count_dct[reasoning_type] / self.all_count_dct[reasoning_type]
+        return self.acc_dct
+
+
 def replace_nested_dict_item(obj, key, replace_value):
     for k, v in obj.items():
         if isinstance(v, dict):


### PR DESCRIPTION
Located the missing function ReasoningTypeAccCalculator which was absent in EgoTaskQA/main_end2end.py
Added the code for ReasoningTypeAccCalculator from the official repository of EgoTaskQA "https://github.com/Buzz-Beater/EgoTaskQA"