### PR TITLE
docs: prefer relative link EgoMQ EgoVLPv2

### DIFF
--- a/EgoMQ/README.md
+++ b/EgoMQ/README.md
@@ -26,7 +26,7 @@ tar -xvzf EgoVLPv2.tgz && rm EgoVLPv2.tgz
 ```
 
 ## 🎯 Fine-tuning on EgoMQ
-This script uses PyTorch’s DataParallel (DP) implementation. For feature extraction, please follow these [steps](/EgoVLPv2#%EF%B8%8F-feature-extraction-on-egomq). To run head-tuning, modify the `Features` variable in `scripts/train_infer_eval_ego_nce.sh` with proper path of extracted features. 
+This script uses PyTorch’s DataParallel (DP) implementation. For feature extraction, please follow these [steps](/EgoVLPv2#%EF%B8%8F-feature-extraction-on-egomq) or as available in [fork](https://github.com/ShramanPramanick/EgoVLPv2/tree/main/EgoVLPv2#%EF%B8%8F-feature-extraction-on-egomq). To run head-tuning, modify the `Features` variable in `scripts/train_infer_eval_ego_nce.sh` with proper path of extracted features. 
 
 ```bash
 # We perform a grid-search for four different hyper-parameters: batch_size, learning_rate, step_size, and step_gamma.

--- a/EgoMQ/README.md
+++ b/EgoMQ/README.md
@@ -1,7 +1,7 @@
 ## 📝 EgoMQ Data Preparation
 
 The EgoMQ metadata can be downloaded from the [Ego4D official webpage](https://ego4d-data.org/). Follow the annotation conversion step [here](https://github.com/EGO4D/episodic-memory/tree/main/MQ#annotation-conversion). Keep the metadata in `jsons/` folder.
-For quickstart, the matadata can be easily downloaded as follows:
+For quickstart, the metadata can be easily downloaded as follows:
 
 ```bash
 wget https://www.cis.jhu.edu/~shraman/EgoVLPv2/datasets/EgoMQ/jsons.tgz
@@ -26,7 +26,7 @@ tar -xvzf EgoVLPv2.tgz && rm EgoVLPv2.tgz
 ```
 
 ## 🎯 Fine-tuning on EgoMQ
-This script uses PyTorch’s DataParallel (DP) implementation. For feature extraction, please follow these [steps](https://github.com/ShramanPramanick/EgoVLPv2/tree/main/EgoVLPv2#%EF%B8%8F-feature-extraction-on-egomq). To run head-tuning, modify the `Features` variable in `scripts/train_infer_eval_ego_nce.sh` with proper path of extracted features. 
+This script uses PyTorch’s DataParallel (DP) implementation. For feature extraction, please follow these [steps](/EgoVLPv2#%EF%B8%8F-feature-extraction-on-egomq). To run head-tuning, modify the `Features` variable in `scripts/train_infer_eval_ego_nce.sh` with proper path of extracted features. 
 
 ```bash
 # We perform a grid-search for four different hyper-parameters: batch_size, learning_rate, step_size, and step_gamma.

--- a/EgoVLPv2/README.md
+++ b/EgoVLPv2/README.md
@@ -114,7 +114,7 @@ $data_root/
 
 ### EgoMQ (feature extraction)
 
-For EgoMQ feature extraction, you need Ego4D resized but non-chunked videos, which will be the output of the first step of video pre-processing (see first bullet of preprocessing [here](#egoclip--egomcq)). The videos will be structured as follows:
+For EgoMQ feature extraction, you need Ego4D resized but non-chunked videos, which will be the output of the first step of video pre-processing (see first bullet of preprocessing [here](#egoclip--egomcq) also available in [fork](https://github.com/ShramanPramanick/EgoVLPv2/blob/main/EgoVLPv2/README.md#egoclip--egomcq)). The videos will be structured as follows:
 ```bash
 $data_root/
     Ego4D_256/
@@ -221,7 +221,7 @@ python test_mq.py --config configs/eval/mq.json --save_dir features_mq --split t
 python test_mq.py --config configs/eval/mq.json --save_dir features_mq --split val --cuda_base cuda:0 --device_ids 0,1,2,3,4,5,6,7
 # Note that the train, test and validation features should be under same root directory. 
 ```
-These pre-extracted features are used for EgoMQ head-tuning, which is shown [here](/EgoMQ#-fine-tuning-on-egomq). 
+These pre-extracted features are used for EgoMQ head-tuning, which is shown [here](/EgoMQ#-fine-tuning-on-egomq) also available in [fork](https://github.com/ShramanPramanick/EgoVLPv2/tree/main/EgoMQ#-fine-tuning-on-egomq). 
 
 ## 🙏 Acknowledgement
 The pre-training pipeline partially uses [EgoVLP](https://github.com/showlab/EgoVLP/tree/f3e8895c7a1a691bc7fb0c07618c3be0015887eb) and [FIBER](https://github.com/microsoft/FIBER) implementations. EK-100 dataloader partially uses [LAVILA](https://github.com/facebookresearch/LaViLa) codebase.

--- a/EgoVLPv2/README.md
+++ b/EgoVLPv2/README.md
@@ -114,7 +114,7 @@ $data_root/
 
 ### EgoMQ (feature extraction)
 
-For EgoMQ feature extraction, you need Ego4D resized but non-chunked videos, which will be the output of the first step of video pre-processing (see first bullet of preprocessing [here](/EgoVLPv2/README.md#egoclip--egomcq)). The videos will be structured as follows:
+For EgoMQ feature extraction, you need Ego4D resized but non-chunked videos, which will be the output of the first step of video pre-processing (see first bullet of preprocessing [here](#egoclip--egomcq)). The videos will be structured as follows:
 ```bash
 $data_root/
     Ego4D_256/

--- a/EgoVLPv2/README.md
+++ b/EgoVLPv2/README.md
@@ -114,7 +114,7 @@ $data_root/
 
 ### EgoMQ (feature extraction)
 
-For EgoMQ feature extraction, you need Ego4D resized but non-chunked videos, which will be the output of the first step of video pre-processing (see first bullet of preprocessing [here](https://github.com/ShramanPramanick/EgoVLPv2/blob/main/EgoVLPv2/README.md#egoclip--egomcq)). The videos will be structured as follows:
+For EgoMQ feature extraction, you need Ego4D resized but non-chunked videos, which will be the output of the first step of video pre-processing (see first bullet of preprocessing [here](/EgoVLPv2/README.md#egoclip--egomcq)). The videos will be structured as follows:
 ```bash
 $data_root/
     Ego4D_256/
@@ -221,7 +221,7 @@ python test_mq.py --config configs/eval/mq.json --save_dir features_mq --split t
 python test_mq.py --config configs/eval/mq.json --save_dir features_mq --split val --cuda_base cuda:0 --device_ids 0,1,2,3,4,5,6,7
 # Note that the train, test and validation features should be under same root directory. 
 ```
-These pre-extracted features are used for EgoMQ head-tuning, which is shown [here](https://github.com/ShramanPramanick/EgoVLPv2/tree/main/EgoMQ#-fine-tuning-on-egomq). 
+These pre-extracted features are used for EgoMQ head-tuning, which is shown [here](/EgoMQ#-fine-tuning-on-egomq). 
 
 ## 🙏 Acknowledgement
 The pre-training pipeline partially uses [EgoVLP](https://github.com/showlab/EgoVLP/tree/f3e8895c7a1a691bc7fb0c07618c3be0015887eb) and [FIBER](https://github.com/microsoft/FIBER) implementations. EK-100 dataloader partially uses [LAVILA](https://github.com/facebookresearch/LaViLa) codebase.


### PR DESCRIPTION
Adjust link in EgoMQ and EgoVLPv2 as [relative link](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#relative-links) also [section link](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#section-links).